### PR TITLE
Fix requirement for PATH_MAX

### DIFF
--- a/plugins/CopyEngine/Ultracopier-Spec/ScanFileOrFolder.cpp
+++ b/plugins/CopyEngine/Ultracopier-Spec/ScanFileOrFolder.cpp
@@ -331,9 +331,14 @@ void ScanFileOrFolder::run()
 INTERNALTYPEPATH ScanFileOrFolder::resolvDestination(const INTERNALTYPEPATH &destination)
 {
     INTERNALTYPEPATH temp(destination);
-    char buf[PATH_MAX];
+    std::string buf(512, '\0');
     ssize_t nbytes=0;
-    nbytes=readlink(TransferThread::internalStringTostring(destination).c_str(), buf, sizeof(buf));
+    do {
+      buf.resize(buf.size()*2);
+      nbytes=readlink(TransferThread::internalStringTostring(destination).c_str(), buf.data(), buf.size());
+    } while (nbytes == buf.size());
+    if (nbytes!=-1)
+      buf.resize(nbytes);
     while(nbytes!=-1) {
         temp=FSabsolutePath(temp);
         if(!stringEndsWith(destination,'/')
@@ -342,14 +347,19 @@ INTERNALTYPEPATH ScanFileOrFolder::resolvDestination(const INTERNALTYPEPATH &des
             #endif
                 )
             temp+=TransferThread::stringToInternalString("/");
-        temp+=TransferThread::stringToInternalString(std::string(buf,nbytes));
+        temp+=TransferThread::stringToInternalString(buf);
         /// \todo change for pure c++ code
         #ifdef WIDESTRING
         temp=QFileInfo(QString::fromStdWString(temp)).absoluteFilePath().toStdWString();
         #else
         temp=QFileInfo(QString::fromStdString(temp)).absoluteFilePath().toStdString();
         #endif
-        nbytes=readlink(TransferThread::internalStringTostring(temp).c_str(), buf, sizeof(buf));
+        do {
+          buf.resize(buf.size() * 2);
+          nbytes=readlink(TransferThread::internalStringTostring(temp).c_str(), buf.data(), buf.size());
+        } while (nbytes == buf.size());
+        if (nbytes!=-1)
+          buf.resize(nbytes);
     }
     return temp;
     /*do


### PR DESCRIPTION
POSIX says PATH_MAX *may* be defined and on GNU Hurd it is in fact not
defined. This commit uses dynamic allocation to avoid relying on
PATH_MAX being defined.