### PR TITLE
Fix linking opus library on Hurd

### DIFF
--- a/other-pro/ultracopier-core.pro
+++ b/other-pro/ultracopier-core.pro
@@ -17,7 +17,7 @@ macx {
 #DEFINES += NOAUDIO
 !contains(DEFINES, NOAUDIO) {
 QT += multimedia
-linux:LIBS += -lopus
+unix:LIBS += -lopus
 win32:LIBS += -lopus
 SOURCES += \
     $$PWD/../libogg/bitwise.c \

--- a/other-pro/ultracopier-little.pro
+++ b/other-pro/ultracopier-little.pro
@@ -3,7 +3,7 @@ android: DEFINES += NOAUDIO
 #DEFINES += NOAUDIO
 !contains(DEFINES, NOAUDIO) {
 QT += multimedia
-linux:LIBS += -lopus
+unix:LIBS += -lopus
 macx:LIBS += -lopus
 win32:LIBS += -lopus
 SOURCES += \


### PR DESCRIPTION
Qmake project files do not contain directives for linking the opus
library on GNU/Hurd. This commit replaces the linux scope for the unix
scope to also include GNU/Hurd in those directives.