### PR TITLE
Change for the correct casing for the word Flags

### DIFF
--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/ar/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/ar/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/de/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/de/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/el/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/el/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/en/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/en/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/es/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/es/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation>Banderas de SO</translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/fr/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/fr/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation>Drapeaux du système d&apos;exploitation</translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/hi/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/hi/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/hu/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/hu/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/id/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/id/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/it/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/it/translation.ts
@@ -839,7 +839,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation>Flags SO</translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/ja/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/ja/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/ko/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/ko/translation.ts
@@ -836,8 +836,8 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
-        <translation type="unfinished">OS FLags</translation>
+        <source>OS Flags</source>
+        <translation type="unfinished">OS Flags</translation>
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="477"/>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/nl/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/nl/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/no/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/no/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/pl/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/pl/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/pt/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/pt/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/ru/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/ru/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/th/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/th/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/tr/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/tr/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/Languages/zh/translation.ts
+++ b/plugins/CopyEngine/Ultracopier-Spec/Languages/zh/translation.ts
@@ -836,7 +836,7 @@
     </message>
     <message>
         <location filename="../../copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/CopyEngine/Ultracopier-Spec/copyEngineOptions.ui
+++ b/plugins/CopyEngine/Ultracopier-Spec/copyEngineOptions.ui
@@ -467,7 +467,7 @@
        <item row="5" column="0">
         <widget class="QLabel" name="label_15">
          <property name="text">
-          <string>OS FLags</string>
+          <string>OS Flags</string>
          </property>
         </widget>
        </item>

--- a/plugins/Languages/ar/translation.ts
+++ b/plugins/Languages/ar/translation.ts
@@ -2347,7 +2347,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/de/translation.ts
+++ b/plugins/Languages/de/translation.ts
@@ -2359,7 +2359,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/el/translation.ts
+++ b/plugins/Languages/el/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/es/translation.ts
+++ b/plugins/Languages/es/translation.ts
@@ -2347,7 +2347,7 @@ Error:%2</translation>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/fr/translation.ts
+++ b/plugins/Languages/fr/translation.ts
@@ -2349,7 +2349,7 @@ Erreur:%2</translation>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/hi/translation.ts
+++ b/plugins/Languages/hi/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/hu/translation.ts
+++ b/plugins/Languages/hu/translation.ts
@@ -2343,7 +2343,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/id/translation.ts
+++ b/plugins/Languages/id/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/it/translation.ts
+++ b/plugins/Languages/it/translation.ts
@@ -2348,7 +2348,7 @@ Errore: %2</translation>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/ja/translation.ts
+++ b/plugins/Languages/ja/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/ko/translation.ts
+++ b/plugins/Languages/ko/translation.ts
@@ -2344,7 +2344,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/nl/translation.ts
+++ b/plugins/Languages/nl/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/no/translation.ts
+++ b/plugins/Languages/no/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/pl/translation.ts
+++ b/plugins/Languages/pl/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/pt/translation.ts
+++ b/plugins/Languages/pt/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/ru/translation.ts
+++ b/plugins/Languages/ru/translation.ts
@@ -2341,7 +2341,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/th/translation.ts
+++ b/plugins/Languages/th/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/tr/translation.ts
+++ b/plugins/Languages/tr/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/Languages/zh_TW/translation.ts
+++ b/plugins/Languages/zh_TW/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/Languages/en/translation.ts
+++ b/resources/Languages/en/translation.ts
@@ -2339,7 +2339,7 @@ Error:%2</source>
     </message>
     <message>
         <location filename="../../../plugins/CopyEngine/Ultracopier-Spec/copyEngineOptions.ui" line="470"/>
-        <source>OS FLags</source>
+        <source>OS Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Changed `OS FLags` to `OS Flags` throughout the app to correct for normal casing. 